### PR TITLE
Update all imod-python gitlab references new github locations

### DIFF
--- a/docs/about.qmd
+++ b/docs/about.qmd
@@ -21,7 +21,7 @@ individual components. You can raise issues, or suggest changes, here.
     Github](https://github.com/Deltares/iMOD-Documentation)
 -   [iMOD QGIS plugin Github](https://github.com/Deltares/imod-qgis)
 -   [iMOD 3D Viewer Github](https://github.com/Deltares/imod-gui)
--   [iMOD Python Gitlab](https://gitlab.com/deltares/imod/imod-python)
+-   [iMOD Python Github](https://github.com/Deltares/imod-python)
 
 
 ## History

--- a/docs/python.qmd
+++ b/docs/python.qmd
@@ -29,9 +29,9 @@ Currently we support the creation of the following MODFLOW-based models:
     (density-dependent groundwater flow) and MT3DMS (multi-species
     reactive transport calculations)
 
-Documentation: <https://deltares.gitlab.io/imod/imod-python> This
+Documentation: <https://deltares.github.io/imod-python/> This
 documentation includes a section \"How do I\" which can be used for
 common data conversions in imod-python or xarray. This section will be
 regular updated based on the different questions of users.
 
-Source code: <https://gitlab.com/deltares/imod/imod-python>
+Source code: <https://github.com/Deltares/imod-python>

--- a/docs/python_install.qmd
+++ b/docs/python_install.qmd
@@ -6,9 +6,9 @@ The recommended way of installing iMOD Python is by running the Deltaforge
 installer. [Read the Deltaforge installation instructions here.](deltaforge_install.qmd)
 
 For other ways to install iMOD Python, [see its documentation.](
-https://deltares.gitlab.io/imod/imod-python/installation.html)
+https://deltares.github.io/imod-python/installation.html)
 
 iMOD Python has no point release schedule, but instead has a \"rolling
 release\", where the package is frequently updated. For the quickest access to
 the latest changes, do a [development
-install.](https://deltares.gitlab.io/imod/imod-python/installation.html#installing-a-newer-or-old-version)
+install.](https://deltares.github.io/imod-python/installation.html#installing-the-latest-development-version)

--- a/docs/qgis_user_manual.qmd
+++ b/docs/qgis_user_manual.qmd
@@ -58,9 +58,9 @@ supports quite a wide range of IPF files. For example, iMOD 5 supports
 both whitespace and comma separated files, whereas the QGIS plugin only
 supports comma separated IPF files. If the plugin is unable to read your
 IPF file, it is best to [read the file with iMOD
-Python](https://deltares.gitlab.io/imod/imod-python/api/generated/io/imod.ipf.read.html)
+Python](https://deltares.github.io/imod-python/api/generated/io/imod.formats.ipf.read.html)
 and consequently [write it
-again](https://deltares.gitlab.io/imod/imod-python/api/generated/io/imod.ipf.write.html).
+again](https://deltares.github.io/imod-python/api/generated/io/imod.formats.ipf.write.html).
 This can help, because the IPF reader in iMOD Python is a lot more
 flexible, but its writer always writes to a specific format. We plan to
 improve the flexibility of the plugin\'s IPF reader.

--- a/docs/tutorial_wq.qmd
+++ b/docs/tutorial_wq.qmd
@@ -24,7 +24,7 @@ The workflow consists of the following steps:
 The iMOD-python script below creates a simple 3D iMOD-WQ model.
 
 To install iMOD-python, see [these
-instructions](https://deltares.gitlab.io/imod/imod-python/installation.html).
+instructions](https://deltares.github.io/imod-python/installation.html).
 
 We define a middle strip which has fresh recharge (`rch`) applied, and
 the sides have a fixed concentration (`bnd = -1`) of 35 (`sconc = 35.`)

--- a/docs/viewer_known_issues.qmd
+++ b/docs/viewer_known_issues.qmd
@@ -33,9 +33,9 @@ quite a wide range of IPF files. For example, iMOD 5 supports both whitespace
 and comma separated files, whereas the QGIS plugin only supports comma
 separated IPF files. If the plugin is unable to read your IPF file, it is best
 to [read the file with iMOD
-Python](https://deltares.gitlab.io/imod/imod-python/api/generated/io/imod.ipf.read.html)
+Python](https://deltares.github.io/imod-python/api/generated/io/imod.formats.ipf.read.html)
 and consequently [write it
-again](https://deltares.gitlab.io/imod/imod-python/api/generated/io/imod.ipf.write.html).
+again](https://deltares.github.io/imod-python/api/generated/io/imod.formats.ipf.write.htm).
 This can help, because the IPF reader in iMOD Python is a lot more flexible,
 but its writer always writes to a specific format. We plan to improve the
 flexibility of the plugin\'s IPF reader.


### PR DESCRIPTION
This commit updates all GitLab references to imod-python by GitHub references
The only exception is a link to a code snippet on GitLab. The reason being that we didn't migrated the snippets