### PR TITLE
Issue #53 add jupyter notebooks to tutorial index

### DIFF
--- a/docs/figures/tutorial/hondsrug/groundwater_decline.png
+++ b/docs/figures/tutorial/hondsrug/groundwater_decline.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0870be644f9dc80ec4282602f903f1d6aec444910a133f5d46b826a01877c84
+size 344483

--- a/docs/figures/tutorial/unstructured_NL/head.png
+++ b/docs/figures/tutorial/unstructured_NL/head.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b6825a8224f6f244954a0e31409a2d4a98572c0cf1e13b31cdedb688700dc0c
+size 233714

--- a/docs/tutorial.qmd
+++ b/docs/tutorial.qmd
@@ -6,6 +6,14 @@ listing:
       - tutorial_Abbeyfeale.qmd
       - tutorial_Dommel.qmd
       - tutorial_wq.qmd
+      - path: tutorial_Hondsrug.ipynb
+        title: "Modifying an existing Modflow 6 model in iMOD Python"
+        image: figures/tutorial/hondsrug/groundwater_decline.png
+        description: "In this tutorial, you will learn how to use iMOD Python for building, running and analysing your MODFLOW 6 model."
+      - path: tutorial_Netherlands_mesh.ipynb
+        title: "Unstructured grid model of the Netherlands"
+        image: figures/tutorial/unstructured_NL/head.png
+        description: "In this example, we'll work with unstructured grid. We'll create a very simple unstructured model of the Netherlands from scratch."
 image: figures/logo/iMOD-tutorial.svg
 description: 'Learn how to use the iMOD Suite'
 index: "5"

--- a/docs/tutorial.qmd
+++ b/docs/tutorial.qmd
@@ -11,7 +11,7 @@ listing:
         image: figures/tutorial/hondsrug/groundwater_decline.png
         description: "In this tutorial, you will learn how to use iMOD Python for building, running and analysing your MODFLOW 6 model."
       - path: tutorial_Netherlands_mesh.ipynb
-        title: "Unstructured grid model of the Netherlands"
+        title: "Unstructured grid model"
         image: figures/tutorial/unstructured_NL/head.png
         description: "In this example, we'll work with unstructured grid. We'll create a very simple unstructured model of the Netherlands from scratch."
 image: figures/logo/iMOD-tutorial.svg


### PR DESCRIPTION
Fixes #53

This adds missing listings of jupyter notebooks. I couldn't figure out how to use the rendered figures in the jupyter notebooks as thumbnails. Adding them in ``image`` in the jupyter options .yml, only caused quarto to ignore them. Hence, the pragmatic way was adding them in the listing manually and adding two figures.

After fixes:

![image](https://github.com/Deltares/iMOD-Documentation/assets/9744750/e9426f16-1540-4f21-b454-beed64788176)
